### PR TITLE
Don't use restore-keys for node_modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,14 +36,14 @@ jobs:
         with:
           path: "node_modules"
           key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
-          restore-keys: ${{ runner.os }}-node_modules
+          # restore-keys: ${{ runner.os }}-node_modules
 
       - uses: actions/cache@v2
         name: Cache scalajs-bundler node_modules
         with:
           path: "*/target/**/main/node_modules"
           key: ${{ runner.os }}-scalajsbundler-node_modules-${{ hashFiles('*/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-scalajsbundler-node_modules
+          # restore-keys: ${{ runner.os }}-scalajsbundler-node_modules
 
       - name: Cache Scalablytyped transpilations
         uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,19 +31,19 @@ jobs:
             ${{ runner.os }}-yarn-
 
 
-      - uses: actions/cache@v2
-        name: Cache node_modules
-        with:
-          path: "node_modules"
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
-          # restore-keys: ${{ runner.os }}-node_modules
+      # - uses: actions/cache@v2
+      #   name: Cache node_modules
+      #   with:
+      #     path: "node_modules"
+      #     key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
+      #     # restore-keys: ${{ runner.os }}-node_modules
 
-      - uses: actions/cache@v2
-        name: Cache scalajs-bundler node_modules
-        with:
-          path: "*/target/**/main/node_modules"
-          key: ${{ runner.os }}-scalajsbundler-node_modules-${{ hashFiles('*/yarn.lock') }}
-          # restore-keys: ${{ runner.os }}-scalajsbundler-node_modules
+      # - uses: actions/cache@v2
+      #   name: Cache scalajs-bundler node_modules
+      #   with:
+      #     path: "*/target/**/main/node_modules"
+      #     key: ${{ runner.os }}-scalajsbundler-node_modules-${{ hashFiles('*/yarn.lock') }}
+      #     # restore-keys: ${{ runner.os }}-scalajsbundler-node_modules
 
       - name: Cache Scalablytyped transpilations
         uses: actions/cache@v2


### PR DESCRIPTION
Locally I couldn't build, because `postcss-loader` was missing, but I can't reproduce this in CI, probably because of `node_modules` caches....

So maybe everything is fine, and I have a strange local state on my side?