### PR TITLE
use json for all encodings, with circe semiautomatic derivation

### DIFF
--- a/api/src/main/scala/example/api/HttpApi.scala
+++ b/api/src/main/scala/example/api/HttpApi.scala
@@ -1,9 +1,9 @@
 package example.api
 
+import io.circe.generic.JsonCodec
 import sttp.tapir._
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
-import io.circe.generic.auto._
 
 // example from: https://github.com/softwaremill/tapir
 
@@ -14,8 +14,8 @@ object HttpApi {
   }
   import types._
 
-  case class BooksFromYear(genre: String, year: Int)
-  case class Book(title: String)
+  @JsonCodec case class BooksFromYear(genre: String, year: Int)
+  @JsonCodec case class Book(title: String)
 
   val booksListing: PublicEndpoint[(BooksFromYear, Limit), String, List[Book], Any] =
     endpoint.get

--- a/api/src/main/scala/example/api/WebsocketApi.scala
+++ b/api/src/main/scala/example/api/WebsocketApi.scala
@@ -1,9 +1,13 @@
 package example.api
 
+import io.circe.generic.JsonCodec
+
 trait WebsocketApi[F[_]] {
-  def numberToString(number: Int): F[String]
+  def sum(numbers: Numbers): F[Int]
   def getRandomNumber: F[Int]
 }
+
+@JsonCodec case class Numbers(a: Int, b: Int)
 
 trait WebsocketEventApi[F[_]] {
   def logs: F[String]

--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,11 @@ ThisBuild / version      := "0.1.0-SNAPSHOT"
 ThisBuild / scalaVersion := "2.13.8"
 
 val versions = new {
-  val outwatch  = "1.0.0-RC8"
-  val colibri   = "0.6.1"
-  val funStack  = "0.7.0"
-  val tapir     = "1.0.4"
-  val boopickle = "1.4.0"
-  val pprint    = "0.7.3"
+  val outwatch = "1.0.0-RC8"
+  val colibri  = "0.6.1"
+  val funStack = "0.7.0"
+  val tapir    = "1.0.4"
+  val pprint   = "0.7.3"
 }
 
 // Uncomment, if you want to use snapshot dependencies from sonatype or jitpack
@@ -72,7 +71,6 @@ lazy val webapp = project
       "io.github.fun-stack"  %%% "fun-stack-web"       % versions.funStack,
       "io.github.fun-stack"  %%% "fun-stack-web-tapir" % versions.funStack, // this pulls in scala-java-time, which will drastically increase the javascript bundle size. Remove if not needed.
       "com.github.cornerman" %%% "colibri-router"      % versions.colibri,
-      "io.suzaku"            %%% "boopickle"           % versions.boopickle,
     ),
     Compile / npmDependencies ++= readJsDependencies(baseDirectory.value, "dependencies") ++ Seq(
       "snabbdom"               -> "github:outwatch/snabbdom.git#semver:0.7.5", // for outwatch, workaround for: https://github.com/ScalablyTyped/Converter/issues/293
@@ -126,7 +124,6 @@ lazy val lambda = project
       "io.github.fun-stack" %%% "fun-stack-lambda-http-rpc"            % versions.funStack,
       "io.github.fun-stack" %%% "fun-stack-lambda-http-api-tapir"      % versions.funStack,
       "io.github.fun-stack" %%% "fun-stack-backend"                    % versions.funStack,
-      "io.suzaku"           %%% "boopickle"                            % versions.boopickle,
       "com.lihaoyi"         %%% "pprint"                               % versions.pprint,
     ),
     Compile / npmDependencies ++= readJsDependencies(baseDirectory.value, "dependencies"),

--- a/cypress/e2e/basic_functionality.cy.js
+++ b/cypress/e2e/basic_functionality.cy.js
@@ -15,7 +15,7 @@ describe("Basic functionality", function () {
 
   it("Websocket RPC API", function () {
     cy.get('.nav-api').click();
-    cy.get('.websocket-rpc-number-to-string').should("have.text", "3");
+    cy.get('.websocket-rpc-sum').should("have.text", "5");
   });
 
   it("Websocket Events", function () {

--- a/lambda/src/main/scala/example/lambda/Entrypoints.scala
+++ b/lambda/src/main/scala/example/lambda/Entrypoints.scala
@@ -5,9 +5,7 @@ import example.api.{HttpRpcApi, WebsocketApi, WebsocketEventApi}
 import funstack.lambda.{http, ws}
 import sloth.Router
 
-import java.nio.ByteBuffer
-import boopickle.Default._
-import chameleon.ext.boopickle._
+import chameleon.ext.circe._
 
 import scala.scalajs.js
 
@@ -19,20 +17,20 @@ object Entrypoints {
 
   @js.annotation.JSExportTopLevel("httpRpc")
   val httpRpc = http.rpc.Handler.handle { request: http.rpc.Handler.Request =>
-    Router[ByteBuffer, IO](new ApiRequestLogger[IO])
+    Router[String, IO](new ApiRequestLogger[IO])
       .route[HttpRpcApi[IO]](new HttpRpcApiImpl(request))
   }
 
   @js.annotation.JSExportTopLevel("wsRpc")
-  val wsRpc = ws.rpc.Handler.handle[ByteBuffer] { request: ws.rpc.Handler.Request =>
-    Router[ByteBuffer, IO](new ApiRequestLogger[IO])
+  val wsRpc = ws.rpc.Handler.handle[String] { request: ws.rpc.Handler.Request =>
+    Router[String, IO](new ApiRequestLogger[IO])
       .route[WebsocketApi[IO]](new WebsocketApiImpl(request))
   }
 
   @js.annotation.JSExportTopLevel("wsEventAuth")
   val wsEventAuth = ws.eventauthorizer.Handler.handleKleisli(
     Router
-      .contra[ByteBuffer, ws.eventauthorizer.Handler.IOKleisli]
+      .contra[String, ws.eventauthorizer.Handler.IOKleisli]
       .route[WebsocketEventApi[ws.eventauthorizer.Handler.IOKleisli]](WebsocketEventApiAuthImpl),
   )
 }

--- a/lambda/src/main/scala/example/lambda/HttpApiImpl.scala
+++ b/lambda/src/main/scala/example/lambda/HttpApiImpl.scala
@@ -9,12 +9,10 @@ import sloth.Client
 import cats.effect.IO
 import cats.data.Kleisli
 
-import java.nio.ByteBuffer
-import boopickle.Default._
-import chameleon.ext.boopickle._
+import chameleon.ext.circe._
 
 object HttpApiImpl {
-  private val client     = Client.contra(Fun.ws.sendTransport[ByteBuffer])
+  private val client     = Client.contra(Fun.ws.sendTransport[String])
   private val streamsApi = client.wire[WebsocketEventApi[Kleisli[IO, *, Unit]]]
 
   val booksListingImpl = HttpApi.booksListing.serverLogic[Handler.IOKleisli] { case (_, _) =>

--- a/lambda/src/main/scala/example/lambda/WebsocketApiImpl.scala
+++ b/lambda/src/main/scala/example/lambda/WebsocketApiImpl.scala
@@ -2,20 +2,18 @@ package example.lambda
 
 import cats.data.Kleisli
 import cats.effect.IO
-import example.api.{WebsocketApi, WebsocketEventApi}
+import example.api.{Numbers, WebsocketApi, WebsocketEventApi}
 import funstack.backend.Fun
 import funstack.lambda.ws.rpc.Handler
 import sloth.Client
 
-import java.nio.ByteBuffer
-import boopickle.Default._
-import chameleon.ext.boopickle._
+import chameleon.ext.circe._
 
 class WebsocketApiImpl(request: Handler.Request) extends WebsocketApi[IO] {
-  private val client     = Client.contra(Fun.ws.sendTransport[ByteBuffer])
+  private val client     = Client.contra(Fun.ws.sendTransport[String])
   private val streamsApi = client.wire[WebsocketEventApi[Kleisli[IO, *, Unit]]]
 
-  def numberToString(number: Int) = IO { number.toString }
+  def sum(numbers: Numbers) = IO { numbers.a + numbers.b }
 
   def getRandomNumber = {
     val userId = request.auth.map(_.sub)

--- a/webapp/src/main/scala/example/webapp/ApiClient.scala
+++ b/webapp/src/main/scala/example/webapp/ApiClient.scala
@@ -6,19 +6,17 @@ import colibri.Observable
 import sloth.Client
 import funstack.web.Fun
 
-import java.nio.ByteBuffer
-import boopickle.Default._
-import chameleon.ext.boopickle._
+import chameleon.ext.circe._
 
 object WsClient {
-  val client                = Client(Fun.ws.transport[ByteBuffer])
+  val client                = Client(Fun.ws.transport[String])
   val api: WebsocketApi[IO] = client.wire[WebsocketApi[IO]]
 
-  val eventClient                             = Client(Fun.ws.streamsTransport[ByteBuffer])
+  val eventClient                             = Client(Fun.ws.streamsTransport[String])
   val eventApi: WebsocketEventApi[Observable] = eventClient.wire[WebsocketEventApi[Observable]]
 }
 
 object HttpClient {
-  val client              = Client(Fun.http.transport[ByteBuffer])
+  val client              = Client(Fun.http.transport[String])
   val api: HttpRpcApi[IO] = client.wire[HttpRpcApi[IO]]
 }

--- a/webapp/src/main/scala/example/webapp/Components.scala
+++ b/webapp/src/main/scala/example/webapp/Components.scala
@@ -1,6 +1,7 @@
 package example.webapp
 
 import colibri.Subject
+import example.api
 import outwatch.dsl._
 import funstack.web.tapir
 
@@ -58,8 +59,8 @@ object Components {
         // example of rendering an async call directly
         // https://outwatch.github.io/docs/readme.html#rendering-futures
         // https://outwatch.github.io/docs/readme.html#rendering-async-effects
-        b("Number to string via api call: "),
-        span(WsClient.api.numberToString(3), cls := "websocket-rpc-number-to-string"),
+        b("Sum via api call: "),
+        span(WsClient.api.sum(api.Numbers(1, 4)), cls := "websocket-rpc-sum"),
       ),
       div(
         // example of dynamic content with EmitterBuilder (onClick), IO (asEffect), and Subject/Observable/Observer (currentRandomNumber)


### PR DESCRIPTION
- Removes boopickle as default encoding
- Adds Api request involving a case class

closes #76 